### PR TITLE
add check if $query empty not add '?' at url

### DIFF
--- a/components/SearchResult.php
+++ b/components/SearchResult.php
@@ -189,12 +189,13 @@ class SearchResult extends ComponentBase
             $cats = Input::get('cat');
             $query = http_build_query(['cat' => $cats]);
             $query = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $query);
+            $query = !empty($query) ? '?' . $query : '';
 
             return Redirect::to(
                 $this->currentPageUrl([
                     $this->searchParam => urlencode($searchTerm)
                 ])
-                . '?' . $query
+                . $query
             );
         }
 


### PR DESCRIPTION
this is usefull plugins for me , but i suggest to check existing $query if $query not exist dont put '?' in url
i think is more clean for url
