### PR TITLE
Fix a highlighting of search results

### DIFF
--- a/components/SearchResult.php
+++ b/components/SearchResult.php
@@ -359,11 +359,11 @@ class SearchResult extends ComponentBase
             $searchTerm = preg_quote($this->searchTerm, '|');
 
             // apply highlight
-            $post->title = preg_replace('|(' . $searchTerm . ')|i', '<mark>$1</mark>', $post->title);
-            $post->excerpt = preg_replace('|(' . $searchTerm . ')|i', '<mark>$1</mark>', $post->excerpt);
+            $post->title = preg_replace('|(' . $searchTerm . ')|iu', '<mark>$1</mark>', $post->title);
+            $post->excerpt = preg_replace('|(' . $searchTerm . ')|iu', '<mark>$1</mark>', $post->excerpt);
 
             $post->content_html = preg_replace(
-                '~(?![^<>]*>)(' . $searchTerm . ')~ism',
+                '~(?![^<>]*>)(' . $searchTerm . ')~ismu',
                 '<mark>$1</mark>',
                 $post->content_html
             );


### PR DESCRIPTION
The highlighting of search results doesn't work for words having a case that is different from the search query. The bug occurs only for Russian (Cyrillic) words, the highlighting works well for English words. The search works well for any words.

The error is in regular expressions that are used to highlight. The `i` key doesn't work for Russian (Cyrillic) symbols without the `u` key.

The example of this error:

![The example of this error](https://cloud.githubusercontent.com/assets/3732121/13978067/6869ef38-f0e7-11e5-966c-c8bed4ff678b.png)

Searched the word `привет`. As you can see, although the post of March 22 has been found, the search word in it isn't highlighted.

The test data to reproduce this error:

``` sql
SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
SET AUTOCOMMIT = 0;
START TRANSACTION;
SET time_zone = "+00:00";

INSERT INTO `rainlab_blog_posts` (`user_id`, `title`, `slug`, `excerpt`, `content`, `content_html`, `published_at`, `published`, `created_at`, `updated_at`) VALUES
(1, 'Hello World', 'hello-world-1', '', 'Hello World', '<p>Hello World</p>', '2016-03-19 21:00:00', 1, '2016-03-23 02:54:36', '2016-03-23 02:54:36'),
(1, 'hello world', 'hello-world-2', '', 'hello world', '<p>hello world</p>', '2016-03-20 21:00:00', 1, '2016-03-23 02:55:04', '2016-03-23 02:55:04'),
(1, 'Привет Мир', 'hello-world-3', '', 'Привет Мир', '<p>Привет Мир</p>', '2016-03-21 21:00:00', 1, '2016-03-23 02:55:30', '2016-03-23 02:56:29'),
(1, 'привет мир', 'hello-world-4', '', 'привет мир', '<p>привет мир</p>', '2016-03-22 21:00:00', 1, '2016-03-23 02:56:14', '2016-03-23 02:56:14');
COMMIT;
```

Insert this data into the database and try to search the word `привет`.
