### PR TITLE
Fixed pagination reference for non-default component names

### DIFF
--- a/components/searchresult/default.htm
+++ b/components/searchresult/default.htm
@@ -27,4 +27,4 @@
     {% endfor %}
 </ul>
 
-{% partial 'searchResult::pagination' posts=posts %}
+{% partial __SELF__~"::pagination" posts=posts %}


### PR DESCRIPTION
The pagination partial reference needs to be __SELF__~”::partialname”
instead of specifying the component name directly. Otherwise, naming
the component something other than the default causes a failure.